### PR TITLE
Update config load and logging

### DIFF
--- a/AttributeModule.psm1
+++ b/AttributeModule.psm1
@@ -88,15 +88,16 @@ function Set-ExtensionAttributes {
 
     if ($ext.Count) {
         Set-ADUser -Identity $UserID -Replace $ext -ErrorAction Stop
-        WriteJobLog "ExtensionAttributes gesetzt: $($ext.Keys -join ', ')" "SUCCESS"
+        # Erfolgsmeldung konsistent über -msg und -Color ausgeben
+        WriteJobLog -msg "ExtensionAttributes gesetzt: $($ext.Keys -join ', ')" -Color Green
     }
 
     if ($isVIP -eq 'j') {
         try {
             Set-ADUser -Identity $UserID -Add @{ pager = 'VIP' } -ErrorAction Stop
-            WriteJobLog "VIP (Quota) gesetzt." "INFO"
+            WriteJobLog -msg "VIP (Quota) gesetzt." -Color Blue
         } catch {
-            WriteJobLog "Fehler VIP: $($_.Exception.Message)" "WARN"
+            WriteJobLog -msg "Fehler VIP: $($_.Exception.Message)" -Color Orange
         }
     }
 }

--- a/MainGUI5.ps1
+++ b/MainGUI5.ps1
@@ -31,9 +31,11 @@ Import-Module "$Script:ToolRoot\ConfigModule.psm1" -Force
     $global:CustomApplication = $app
 }
 
-# Lade Konfigurationsdateien
-$global:AppConfig = Get-Content "\\office.dir\files\ORG\OrgDATA\IT-BMU\03_Tools\AddUser-GUI\AddUser_v22\config.json" -Raw -Encoding UTF8 | ConvertFrom-Json
+# Lade die Konfiguration einmal über das ConfigModule (cacht intern)
+$global:AppConfig = Get-AppConfig
+# StdProfiles werden weiter aus der separaten Datei geladen
 $global:StdProfiles = Get-Content "\\office.dir\files\ORG\OrgDATA\IT-BMU\03_Tools\AddUser-GUI\AddUser_v22\stdprofiles.json" -Raw -Encoding UTF8 | ConvertFrom-Json
+# Importiere Mailbox und Profile Module separat (falls nicht über $global:AppConfig.Modules abgedeckt)
 Import-Module "\\office.dir\files\ORG\OrgDATA\IT-BMU\03_Tools\AddUser-GUI\AddUser_v22\MailboxModule.psm1"
 Import-Module "\\office.dir\files\ORG\OrgDATA\IT-BMU\03_Tools\AddUser-GUI\AddUser_v22\ProfileModule.psm1"
 


### PR DESCRIPTION
## Summary
- load config via `Get-AppConfig` and cache it
- standardize logging for extension attributes

## Testing
- `pwsh` was unavailable so tests could not run

------
https://chatgpt.com/codex/tasks/task_e_6883c815c1188321955c4866b97ec418