### PR TITLE
Fix logging paths & config init

### DIFF
--- a/ADUserCreationModule.psm1
+++ b/ADUserCreationModule.psm1
@@ -33,8 +33,20 @@ function new-ADAccountSettings {
         $newUserData.expirationDate = ([datetime](Get-Date ($expirationDate + " 00:00:00")).AddDays(1))
     } #>
 
-    if ($global:AppConfig.LogInLog) {
-        "$($newUserData.UserloginName) : $userLoginPassword" | Out-File -FilePath $global:AppConfig.LogInLog -Append
+    $loginLog = $null
+    if ($global:AppConfig -and $global:AppConfig.Paths -and $global:AppConfig.Paths.LogInLog) {
+        $loginLog = $global:AppConfig.Paths.LogInLog
+    }
+    if ($loginLog) {
+        $dir = [IO.Path]::GetDirectoryName($loginLog)
+        if (-not (Test-Path -LiteralPath $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        }
+        try {
+            "$($newUserData.UserloginName) : $userLoginPassword" | Out-File -FilePath $loginLog -Append
+        } catch {
+            Write-Warning "Konnte Log-Datei '$loginLog' nicht beschreiben: $($_.Exception.Message)"
+        }
     }
 
     Write-Log -Message "new-ADAccountSettings - Datenobjekt erstellt für $newUserID" -Color "green"

--- a/ConfigModule.psm1
+++ b/ConfigModule.psm1
@@ -41,6 +41,9 @@ function Get-AppConfig {
     }
     try {
         $script:AppConfig = Get-Content -LiteralPath $resolved -Raw -Encoding UTF8 | ConvertFrom-Json
+        if ($env:ADDUSER_LOGPATH) {
+            $script:AppConfig.Paths.LogPath = $env:ADDUSER_LOGPATH
+        }
         Write-Log -Message "Config loaded & cached from '$resolved'." -Category DEBUG
         return $script:AppConfig
     } catch {

--- a/DatabaseModule.psm1
+++ b/DatabaseModule.psm1
@@ -1,7 +1,19 @@
 # DatabaseModule.psm1
+
+function Ensure-Directory {
+    param([string]$Path)
+    if (-not $Path) {
+        throw "Pfad darf nicht NULL sein (aufrufende Funktion: $MyInvocation.MyCommand)"
+    }
+    $dir = [IO.Path]::GetDirectoryName($Path)
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+}
 function set-database {
     param([Parameter(Mandatory=$true)][string]$pathToFile)
     Write-Log -Message "set-database: Prüfe $pathToFile" -Color "blue"
+    Ensure-Directory $pathToFile
     if (!(Test-Path $pathToFile)) {
         try {
             $XmlWriter = New-Object System.Xml.XmlTextWriter($pathToFile, $null)
@@ -28,8 +40,9 @@ function check-Database {
     param([Parameter(Mandatory=$true)][string]$UserID)
     Write-Log -Message "check-Database: Prüfe DB-Eintrag für $UserID" -Color "blue"
     try {
-        if (Test-Path $global:AppConfig.FilePath) {
-            [xml]$doc = Get-Content $global:AppConfig.FilePath
+        $dbPath = $global:AppConfig.Paths.FilePath
+        if ($dbPath -and (Test-Path -LiteralPath $dbPath)) {
+            [xml]$doc = Get-Content $dbPath
             $users = $doc.SelectSingleNode("//User[translate(@ID, 'A-Z', 'a-z') = translate('$UserID', 'A-Z', 'a-z')]")
             if ($users) { return $users }
             else        { return $false }
@@ -46,11 +59,13 @@ function delete-record {
     param([Parameter(Mandatory=$true)][string]$UserID)
     Write-Log -Message "delete-record: Lösche $UserID in DB" -Color "blue"
     try {
-        [xml]$doc = Get-Content $global:AppConfig.FilePath
+        $dbPath = $global:AppConfig.Paths.FilePath
+        Ensure-Directory $dbPath
+        [xml]$doc = Get-Content $dbPath
         $users = $doc.SelectSingleNode("//User[translate(@ID, 'A-Z', 'a-z') = translate('$UserID', 'A-Z', 'a-z')]")
         if ($users) {
             [Void]$users.ParentNode.RemoveChild($users)
-            $doc.Save($global:AppConfig.FilePath)
+            $doc.Save($dbPath)
             Write-Log -Message "Tupel $UserID gelöscht." -Color "green"
             return $true
         }
@@ -71,9 +86,10 @@ function append-database {
         [Parameter(Mandatory=$true)]$ticketNr
     )
     Write-Log -Message "append-database: $($userAttributes.id)" -Color "blue"
-    if (set-database -pathToFile $global:AppConfig.FilePath) {
+    $dbPath = $global:AppConfig.Paths.FilePath
+    if (set-database -pathToFile $dbPath) {
         try {
-            [xml]$doc = Get-Content $global:AppConfig.FilePath
+            [xml]$doc = Get-Content $dbPath
             $user = $doc.CreateElement("User")
             $user.SetAttribute("ID", $userAttributes.id)
             $user.SetAttribute("Date", $userAttributes.datum)
@@ -87,7 +103,7 @@ function append-database {
             $node.AppendChild($doc.CreateTextNode($userAttributes.extensionAttribute14))
 
             $doc.DocumentElement.AppendChild($user)
-            $doc.Save($global:AppConfig.FilePath)
+            $doc.Save($dbPath)
             Write-Log -Message "Datensatz für $($userAttributes.id) angehängt." -Color "green"
             return $true
         }
@@ -105,9 +121,10 @@ function write-XMLLog {
         [Parameter(Mandatory=$true)]$ticketNr
     )
     Write-Log -Message "write-XMLLog: $($logUserAttributes.id) - $ticketNr" -Color "blue"
-    if (set-database -pathToFile $global:AppConfig.XMLLogPath) {
+    $xmlPath = $global:AppConfig.Paths.XMLLogPath
+    if (set-database -pathToFile $xmlPath) {
         try {
-            [xml]$logDoc = Get-Content $global:AppConfig.XMLLogPath
+            [xml]$logDoc = Get-Content $xmlPath
             $editor   = whoami
             $EditDate = Get-Date -Format "dd.MM.yyyy HH.mm"
             $logUser = $logDoc.CreateElement("Ticket")
@@ -129,7 +146,7 @@ function write-XMLLog {
             $logNode.AppendChild($logDoc.CreateTextNode($logUserAttributes.extensionAttribute14))
 
             $logDoc.DocumentElement.AppendChild($logUser)
-            $logDoc.Save($global:AppConfig.XMLLogPath)
+            $logDoc.Save($xmlPath)
             Write-Log -Message "write-XMLLog: Ticket $ticketNr eingetragen." -Color "green"
             return $true
         }

--- a/UserCreationLogic2.psm1
+++ b/UserCreationLogic2.psm1
@@ -67,6 +67,9 @@ function ProcessUserCreation {
         [switch]$InJob,                                     # Hintergundmodus (z. B. per Scheduled Job)
         [scriptblock]$ProgressCallback                      # Fortschrittsrückruf-Funktion
     )
+    if (-not $global:AppConfig) {
+        throw 'Globales AppConfig-Objekt nicht initialisiert – Abbruch!'
+    }
     # Prüfe, ob ein Aktivierungsdatum gesetzt wurde (und nicht "S" für sofort)
     #$useDelayedActivation = $false
     #if ($EntryDate -and $EntryDate -ne "S") {

--- a/tests/TestHelpers.ps1
+++ b/tests/TestHelpers.ps1
@@ -14,5 +14,8 @@ function Use-TestConfig {
     # Direkt in den ConfigModule-Cache schreiben ist unsauber – deshalb:
     # Wir setzen Env-Var, so dass Get-AppConfig unseren Testpfad nimmt.
     $env:ADDUSER_CONFIG_PATH = $ConfigPath
+    $env:ADDUSER_LOGPATH    = Join-Path $env:TEMP 'AddUserTest.log'
+    Import-Module (Join-Path $PSScriptRoot '..\ConfigModule.psm1') -Force
+    $global:AppConfig = Get-AppConfig
 }
 


### PR DESCRIPTION
## Summary
- ensure database and AD logging use `AppConfig.Paths.*`
- auto-create directories for database and log files
- override log path via `$env:ADDUSER_LOGPATH`
- verify `AppConfig` is loaded before running `ProcessUserCreation`
- load config in tests with env override

## Testing
- `pwsh -NoLogo -Command "& { ./scripts/Invoke-Tests.ps1 }"` *(fails: Pester not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883ec3e56548321b7f27394c7351701