### PR TITLE
Fix CI to use Windows PowerShell 5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,17 @@ on:
   push:
   pull_request:
 jobs:
-  pester:
+  build-test:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run Pester
-        shell: pwsh
+
+      #   ---------- TESTS ----------
+      - name: Pester-Tests & Linting
+        shell: powershell
         run: |
-          pwsh -f scripts/Invoke-Tests.ps1
+          # Fail fast
+          $ErrorActionPreference = 'Stop'
+
+          # Starte alle Unit-Tests
+          Invoke-Pester -Path .\tests -EnableExit

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ nutzen – der bestehende Code ändert sich dadurch nicht.
 ## Tests
 
 ```powershell
-pwsh -f scripts\Invoke-Tests.ps1
+powershell -File scripts\Invoke-Tests.ps1
 ```
 
 ## EXE bauen (optional, ohne Funktionalitätsänderung)
 
 ```powershell
-pwsh -f scripts\build.ps1
+powershell -File scripts\build.ps1
 ```
 
 Ergebnis: `dist\AddUserGUI.exe` (+ Payload-Ordner).


### PR DESCRIPTION
## Summary
- run CI on Windows PowerShell 5.1 instead of pwsh
- update README so the docs use `powershell` rather than `pwsh`

## Testing
- `powershell -File scripts/Invoke-Tests.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883ec612838832199e9a4a9e45f06c3